### PR TITLE
LM Demo3 with Temporal Memory

### DIFF
--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -25,7 +25,7 @@ $$
 I_i = \sum_j J_{ij}s_j + h_i(\mathrm{token}) + \alpha s_i(\mathrm{previous})
 $$
 
-where $\alpha$ is the memory scale.
+where $\alpha$ controls the strength of the recurrent memory feedback.
 
 ## Workflow
 
@@ -50,8 +50,8 @@ The sparse p-bit architecture is intended to be hardware-friendly: the same mode
 
 # Future research
 
-* Scale the p-bit reservoir and study quality vs number of p-bits, sparse connections, and trainable parameters.
-* Add persistent solver state once supported, instead of feeding the previous state back through h.
+* Scale the p-bit reservoir and study quality vs number of p-bits, sparse connections, and trainable parameters
+* Add persistent solver state once supported, instead of feeding the previous state back through h - DONE (both are supported now)
 * Test a more p-kit-native hybrid architecture:
 
 `token => p-bit reservoir => p-kit ReLU / nonlinear p-bit blocks => probabilistic p-bit output layer => posterior next-token sampling`

--- a/examples/llm/llm_demo_003.py
+++ b/examples/llm/llm_demo_003.py
@@ -1,34 +1,33 @@
 """
 llm_demo_003.py
 
-Study memory depth in SparsePBitLMAdvanced. This is a version with explicit temporal memory.
+Study explicit temporal memory in SparsePBitLMTemporalMemory.
 
 Question:
 Does a longer reservoir-state history improve language quality while
 keeping the 128-pbit reservoir fixed and without backpropagation through it?
 
+Best configuration:
+  history_size=8
+  memory_scale=0.35
+  use_initial_state=False
+
 Requires: pip install "transformers[torch]"
 
 Results
- History  Trainable     Acc      PPL     Time
-       1       3360   0.561   13.730    1.62s
-       2       6048   0.671   13.107    1.57s
-       4      11424   0.768   12.555    2.02s
-       8      22176   0.793   12.155    2.70s *
-      16      43680   0.768   12.169    3.02s
-     GPT     103488   0.829    2.294    2.17s #
-     
-The optimum here is history = 8.
-We have 79.3% accuracy vs the base line GPT 82.9%.
-22,176 vs 103,488 trainable parameters => 4.7× fewer then GPT.
-No backpropagation through the p-bit reservoir.
-Similar training time: 2.70s vs 2.17s.
+     Model  Trainable     Acc      PPL     Time
+     p-kit      22176   0.793   12.155    1.67s
+       GPT     103488   0.829    2.294    2.21s
+
+The p-kit model reaches 79.3% accuracy vs 82.9% for the GPT baseline.
+It uses 22,176 vs 103,488 trainable parameters, about 4.7x fewer.
+There is no backpropagation through the p-bit reservoir.
+Training time is similar in this small experiment.
 """
 
 import math, time
 import numpy as np
 import torch
-import matplotlib.pyplot as plt
 from torch.utils.data import DataLoader
 from transformers import GPT2Config, GPT2LMHeadModel
 from llm_model import SparsePBitLMTemporalMemory
@@ -52,8 +51,7 @@ the dog moved to the mat.
 the robot looked at the cat.
 """
 
-VOCAB = sorted(set(TRAIN))
-C2I = {c:i for i,c in enumerate(VOCAB)}
+VOCAB=sorted(set(TRAIN)); C2I={c:i for i,c in enumerate(VOCAB)}
 def encode(text): return [C2I[c] for c in text]
 
 def evaluate_pkit(model):
@@ -61,9 +59,9 @@ def evaluate_pkit(model):
     for current,target in zip(TEST[:-1],TEST[1:]):
         p=model.next_char_probabilities(current,temperature=1.0)
         tid=model.char_to_id[target]
-        correct += int(np.argmax(p)==tid)
-        nll -= math.log(max(float(p[tid]),1e-12)); total += 1
-    return correct/total, math.exp(nll/total)
+        correct+=int(np.argmax(p)==tid)
+        nll-=math.log(max(float(p[tid]),1e-12)); total+=1
+    return correct/total,math.exp(nll/total)
 
 def train_gpt(context=32,epochs=15):
     ids=encode(TRAIN)
@@ -89,45 +87,34 @@ def evaluate_gpt(model,context=32):
         for t in range(1,len(ids)):
             x=torch.tensor(ids[max(0,t-context):t]).unsqueeze(0)
             p=torch.softmax(model(x).logits[0,-1],dim=-1)
-            correct += int(torch.argmax(p)==ids[t])
-            nll -= math.log(max(float(p[ids[t]]),1e-12)); total += 1
+            correct+=int(torch.argmax(p)==ids[t])
+            nll-=math.log(max(float(p[ids[t]]),1e-12)); total+=1
     return correct/total,math.exp(nll/total)
 
 def main():
     np.random.seed(7); torch.manual_seed(7)
 
+    print("Training p-kit model...")
+    pkit=SparsePBitLMTemporalMemory(
+        n_pbits=128,degree=8,input_fanout=16,
+        recurrent_scale=.40,input_scale=1.4,
+        memory_scale=.35,history_size=8,
+        use_initial_state=False,seed=7)
+
+    start=time.perf_counter()
+    pkit.fit(TRAIN,washout=30,ridge=.05)
+    pkit_time=time.perf_counter()-start
+    pkit_acc,pkit_ppl=evaluate_pkit(pkit)
+
     print("Training GPT baseline...")
     gpt,gpt_time=train_gpt()
     gpt_acc,gpt_ppl=evaluate_gpt(gpt)
-    gpt_params=sum(p.numel() for p in gpt.parameters())
-
-    results=[]
-    for h in (1,2,4,8,16):
-        print(f"Training p-kit history={h}...")
-        model=SparsePBitLMTemporalMemory(
-            n_pbits=128,degree=8,input_fanout=16,
-            recurrent_scale=.40,input_scale=1.4,
-            memory_scale=.35,history_size=h,seed=7)
-
-        start=time.perf_counter()
-        model.fit(TRAIN,washout=30,ridge=.05)
-        elapsed=time.perf_counter()-start
-        acc,ppl=evaluate_pkit(model)
-        results.append((h,model.readout.size,acc,ppl,elapsed))
 
     print("\nResults")
-    print(f"{'History':>8} {'Trainable':>10} {'Acc':>7} {'PPL':>8} {'Time':>8}")
-    for h,p,acc,ppl,t in results:
-        print(f"{h:8d} {p:10d} {acc:7.3f} {ppl:8.3f} {t:7.2f}s")
-    print(f"{'GPT':>8} {gpt_params:10d} {gpt_acc:7.3f} {gpt_ppl:8.3f} {gpt_time:7.2f}s")
+    print(f"{'Model':>10} {'Trainable':>10} {'Acc':>7} {'PPL':>8} {'Time':>8}")
+    print(f"{'p-kit':>10} {pkit.readout.size:10d} {pkit_acc:7.3f} {pkit_ppl:8.3f} {pkit_time:7.2f}s")
+    print(f"{'GPT':>10} {sum(p.numel() for p in gpt.parameters()):10d} "
+          f"{gpt_acc:7.3f} {gpt_ppl:8.3f} {gpt_time:7.2f}s")
 
-    h=[r[0] for r in results]
-    acc=[r[2] for r in results]
-    plt.plot(h,acc,"o-",label="p-kit")
-    plt.axhline(gpt_acc,linestyle="--",label="Tiny GPT")
-    plt.xlabel("History depth"); plt.ylabel("Test accuracy")
-    plt.title("p-kit memory-depth scaling")
-    plt.xticks(h); plt.grid(); plt.legend(); plt.show()
-
-if __name__ == "__main__":
+if __name__=="__main__":
     main()

--- a/examples/llm/llm_demo_003.py
+++ b/examples/llm/llm_demo_003.py
@@ -20,7 +20,7 @@ Results
        GPT     103488   0.829    2.294    2.21s
 
 The p-kit model reaches 79.3% accuracy vs 82.9% for the GPT baseline.
-It uses 22,176 vs 103,488 trainable parameters, about 4.7x fewer.
+The p-kit model uses 22,176 vs 103,488 trainable parameters, about 4.7x fewer than GPT.
 There is no backpropagation through the p-bit reservoir.
 Training time is similar in this small experiment.
 """

--- a/examples/llm/llm_demo_003.py
+++ b/examples/llm/llm_demo_003.py
@@ -1,0 +1,133 @@
+"""
+llm_demo_003.py
+
+Study memory depth in SparsePBitLMAdvanced. This is a version with explicit temporal memory.
+
+Question:
+Does a longer reservoir-state history improve language quality while
+keeping the 128-pbit reservoir fixed and without backpropagation through it?
+
+Requires: pip install "transformers[torch]"
+
+Results
+ History  Trainable     Acc      PPL     Time
+       1       3360   0.561   13.730    1.62s
+       2       6048   0.671   13.107    1.57s
+       4      11424   0.768   12.555    2.02s
+       8      22176   0.793   12.155    2.70s *
+      16      43680   0.768   12.169    3.02s
+     GPT     103488   0.829    2.294    2.17s #
+     
+The optimum here is history = 8.
+We have 79.3% accuracy vs the base line GPT 82.9%.
+22,176 vs 103,488 trainable parameters => 4.7× fewer then GPT.
+No backpropagation through the p-bit reservoir.
+Similar training time: 2.70s vs 2.17s.
+"""
+
+import math, time
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+from torch.utils.data import DataLoader
+from transformers import GPT2Config, GPT2LMHeadModel
+from llm_model import SparsePBitLMTemporalMemory
+
+TRAIN = """
+the cat sat on the mat.
+the dog sat by the door.
+the cat looked at the dog.
+the dog looked at the cat.
+the cat walked to the door.
+the dog walked to the mat.
+the small robot saw the cat.
+the small robot saw the dog.
+the robot moved to the door.
+the robot moved to the mat.
+""" * 20
+
+TEST = """
+the cat moved to the door.
+the dog moved to the mat.
+the robot looked at the cat.
+"""
+
+VOCAB = sorted(set(TRAIN))
+C2I = {c:i for i,c in enumerate(VOCAB)}
+def encode(text): return [C2I[c] for c in text]
+
+def evaluate_pkit(model):
+    model.reset(); correct=total=0; nll=0
+    for current,target in zip(TEST[:-1],TEST[1:]):
+        p=model.next_char_probabilities(current,temperature=1.0)
+        tid=model.char_to_id[target]
+        correct += int(np.argmax(p)==tid)
+        nll -= math.log(max(float(p[tid]),1e-12)); total += 1
+    return correct/total, math.exp(nll/total)
+
+def train_gpt(context=32,epochs=15):
+    ids=encode(TRAIN)
+    blocks=[torch.tensor(ids[i:i+context]) for i in range(0,len(ids)-context,context//2)]
+    model=GPT2LMHeadModel(GPT2Config(
+        vocab_size=len(VOCAB),n_positions=context,n_ctx=context,
+        n_embd=64,n_layer=2,n_head=2,
+        resid_pdrop=0,embd_pdrop=0,attn_pdrop=0,
+        bos_token_id=None,eos_token_id=None))
+    loader=DataLoader(blocks,batch_size=16,shuffle=True)
+    opt=torch.optim.AdamW(model.parameters(),lr=3e-3)
+    start=time.perf_counter(); model.train()
+    for _ in range(epochs):
+        for batch in loader:
+            opt.zero_grad()
+            loss=model(input_ids=batch,labels=batch).loss
+            loss.backward(); opt.step()
+    return model,time.perf_counter()-start
+
+def evaluate_gpt(model,context=32):
+    ids=encode(TEST); correct=total=0; nll=0; model.eval()
+    with torch.no_grad():
+        for t in range(1,len(ids)):
+            x=torch.tensor(ids[max(0,t-context):t]).unsqueeze(0)
+            p=torch.softmax(model(x).logits[0,-1],dim=-1)
+            correct += int(torch.argmax(p)==ids[t])
+            nll -= math.log(max(float(p[ids[t]]),1e-12)); total += 1
+    return correct/total,math.exp(nll/total)
+
+def main():
+    np.random.seed(7); torch.manual_seed(7)
+
+    print("Training GPT baseline...")
+    gpt,gpt_time=train_gpt()
+    gpt_acc,gpt_ppl=evaluate_gpt(gpt)
+    gpt_params=sum(p.numel() for p in gpt.parameters())
+
+    results=[]
+    for h in (1,2,4,8,16):
+        print(f"Training p-kit history={h}...")
+        model=SparsePBitLMTemporalMemory(
+            n_pbits=128,degree=8,input_fanout=16,
+            recurrent_scale=.40,input_scale=1.4,
+            memory_scale=.35,history_size=h,seed=7)
+
+        start=time.perf_counter()
+        model.fit(TRAIN,washout=30,ridge=.05)
+        elapsed=time.perf_counter()-start
+        acc,ppl=evaluate_pkit(model)
+        results.append((h,model.readout.size,acc,ppl,elapsed))
+
+    print("\nResults")
+    print(f"{'History':>8} {'Trainable':>10} {'Acc':>7} {'PPL':>8} {'Time':>8}")
+    for h,p,acc,ppl,t in results:
+        print(f"{h:8d} {p:10d} {acc:7.3f} {ppl:8.3f} {t:7.2f}s")
+    print(f"{'GPT':>8} {gpt_params:10d} {gpt_acc:7.3f} {gpt_ppl:8.3f} {gpt_time:7.2f}s")
+
+    h=[r[0] for r in results]
+    acc=[r[2] for r in results]
+    plt.plot(h,acc,"o-",label="p-kit")
+    plt.axhline(gpt_acc,linestyle="--",label="Tiny GPT")
+    plt.xlabel("History depth"); plt.ylabel("Test accuracy")
+    plt.title("p-kit memory-depth scaling")
+    plt.xticks(h); plt.grid(); plt.legend(); plt.show()
+
+if __name__ == "__main__":
+    main()

--- a/examples/llm/llm_model.py
+++ b/examples/llm/llm_model.py
@@ -4,11 +4,15 @@ Sparse p-bit reservoir language model - a proof of concept.
 Reservoir computing: a recurrent network with mostly fixed internal connections
 that converts the input sequence into a rich dynamic state.
 
-This is a small demo model. The recurrent state is made of stochastic p-bits
+This is a small demo model. The recurrent state is made of stochastic p-bits 
 with sparse pairwise couplings:
 
     P(s_i = +1) = (1 + tanh(beta * I_i)) / 2
     I_i = sum_j J_ij s_j + h_i(token) + memory_scale * s_i(previous)
+
+By default each solver call starts from a new stochastic state. Optionally,
+CaSuDaSolver can continue from the previous reservoir state using
+use_initial_state=True.
 
 The p-bit reservoir is sparse and thus hardware-friendly. A conventional linear
 readout is trained with ridge regression to predict the next character.
@@ -38,10 +42,6 @@ NOTES:
   - Similar to an RNN, more specifically an Echo State Network / reservoir computer:
   - Training is much simpler and cheaper because there is no backpropagation through the recurrent network.
 
-Currently a workaround is used for the recurrent memory: feed the previous 
-reservoir state back through h because CaSuDaSolver cannot yet start from a 
-user-provided initial state. Once https://github.com/IBM/p-kit/issues/117 is
-implemented, this can be replaced by passing self.state directly to the solver.
 """
 
 from dataclasses import dataclass
@@ -70,6 +70,7 @@ class SparsePBitLM:
         memory_scale=0.35,
         reservoir_steps=10,
         relu_steps=10,
+        use_initial_state=False,
         seed=1,
     ):
         self.n_pbits = int(n_pbits)
@@ -77,6 +78,7 @@ class SparsePBitLM:
         self.input_fanout = int(input_fanout)
         self.input_scale = float(input_scale)
         self.memory_scale = float(memory_scale)
+        self.use_initial_state = use_initial_state
 
         self.rng = np.random.default_rng(seed)
 
@@ -216,35 +218,20 @@ class SparsePBitLM:
             size=self.n_pbits,
         )
 
-    def step(
-        self,
-        token_id,
-        sweeps=1,
-    ):
-        """
-        Advance the recurrent reservoir using the p-kit solver.
-        """
-
+    def step(self, token_id, sweeps=1):
+        
         for _ in range(sweeps):
-
-            # Token input + recurrent state feedback.
-            #
-            # The feedback through h is temporary until p-kit can
-            # initialize CaSuDaSolver directly from self.state.
             self.circuit.h = (
                 self.token_h[token_id]
                 + self.memory_scale * self.state
             )
-
-            _, trajectory, _ = (
-                self.reservoir_solver.solve(
-                    self.circuit
-                )
+    
+            _, trajectory, _ = self.reservoir_solver.solve(
+                self.circuit,
+                initial_state=self.state if self.use_initial_state else None,
             )
-
-            self.state = (
-                trajectory[-1].astype(float)
-            )
+    
+            self.state = trajectory[-1].astype(float)
 
         return self.state
 

--- a/examples/llm/llm_model.py
+++ b/examples/llm/llm_model.py
@@ -460,3 +460,52 @@ class SparsePBitLM:
             self.n_connections
             / self.circuit.J.size
         )
+    
+class SparsePBitLMTemporalMemory(SparsePBitLM):
+    """
+    SparsePBitLM with explicit temporal memory.
+
+    The readout receives several consecutive reservoir states instead of
+    only the current one:
+
+        token -> p-bit reservoir -> [s(t), s(t-1), ...] -> readout
+
+    This tests whether additional temporal context improves language modeling
+    without training the recurrent p-bit reservoir itself.
+    """
+
+    def __init__(self, *args, history_size=4, **kwargs):
+        self.history_size = history_size
+        super().__init__(*args, **kwargs)
+        self._reset_history()
+
+    def _reset_history(self):
+        self.state_history = [
+            np.zeros(self.n_pbits, dtype=float)
+            for _ in range(self.history_size)
+        ]
+
+    def reset(self):
+        super().reset()
+        if hasattr(self, "history_size") and hasattr(self, "n_pbits"):
+            self._reset_history()
+
+    def step(self, token_id, sweeps=1):
+        state = super().step(token_id, sweeps=sweeps)
+        self.state_history = [state.copy()] + self.state_history[:-1]
+        return state
+
+    def _features(self, token_id, sweeps=1):
+        self.step(token_id, sweeps=sweeps)
+        relu = self.relu_features()
+        memory = np.concatenate(self.state_history)
+    
+        token_feature = np.zeros(len(self.char_to_id))
+        token_feature[token_id] = 1.0
+    
+        return np.concatenate([
+            memory,
+            relu,
+            token_feature,
+            [1.0],
+        ])

--- a/p_kit/solver/csd_solver.py
+++ b/p_kit/solver/csd_solver.py
@@ -7,7 +7,7 @@ import numpy as np
 class CaSuDaSolver(Solver):
     # K. Y. Camsari, B. M. Sutton, and S. Datta, 'p-bits for probabilistic spin logic', Applied Physics Reviews, vol. 6, no. 1, p. 011305, Mar. 2019, doi: 10.1063/1.5055860.
 
-    def solve(self, c: PCircuit, annealing_func=constant, n_shots=1):
+    def solve(self, c: PCircuit, annealing_func=constant, n_shots=1, initial_state=None):
 
         # credit: https://www.purdue.edu/p-bit/blog.html
         xp = self.xp
@@ -21,7 +21,16 @@ class CaSuDaSolver(Solver):
         all_m = xp.zeros((self.Nt, n_shots, n_pbits))
         all_I = xp.zeros((self.Nt, n_pbits))
         E = xp.zeros(self.Nt)
-        m = xp.sign(0.5 - self.random((n_shots, n_pbits)))
+
+        if initial_state is None:
+            m = xp.sign(0.5 - self.random((n_shots, n_pbits)))
+        else:
+            state = xp.asarray(initial_state).flatten()
+            if state.shape != (n_pbits,):
+                raise ValueError(f"initial_state must have shape ({n_pbits},)")
+            if not bool(xp.all((state == -1) | (state == 1))):
+                raise ValueError("initial_state must contain only -1 or +1")
+            m = xp.tile(state, (n_shots, 1))
 
         for run in range(self.Nt):
             I = annealing_func(self, run) * (m @ J + h)

--- a/p_kit/solver/csd_solver.py
+++ b/p_kit/solver/csd_solver.py
@@ -25,9 +25,10 @@ class CaSuDaSolver(Solver):
         if initial_state is None:
             m = xp.sign(0.5 - self.random((n_shots, n_pbits)))
         else:
-            state = xp.asarray(initial_state).flatten()
-            if state.shape != (n_pbits,):
-                raise ValueError(f"initial_state must have shape ({n_pbits},)")
+            state = xp.asarray(initial_state)
+            if state.size != n_pbits:
+                raise ValueError(f"initial_state must contain {n_pbits} values")
+            state = state.reshape(n_pbits)
             if not bool(xp.all((state == -1) | (state == 1))):
                 raise ValueError("initial_state must contain only -1 or +1")
             m = xp.tile(state, (n_shots, 1))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,28 @@
+import numpy as np
 import pytest
 
+from p_kit.psl.p_circuit import PCircuit
+from p_kit.solver.csd_solver import CaSuDaSolver
 
-def test_canary():
-    assert True
+def test_casuda_initial_state():
+    c = PCircuit(3)
+    solver = CaSuDaSolver(Nt=1, dt=0.0, i0=0.8, seed=1)
+    state = np.array([1, -1, 1])
+
+    _, output, _ = solver.solve(c, initial_state=state)
+
+    assert np.array_equal(output[0], state)
+
+def test_casuda_initial_state_shape():
+    c = PCircuit(3)
+    solver = CaSuDaSolver(Nt=1, dt=0.0, i0=0.8)
+
+    with pytest.raises(ValueError):
+        solver.solve(c, initial_state=np.array([1, -1]))
+
+def test_casuda_initial_state_values():
+    c = PCircuit(3)
+    solver = CaSuDaSolver(Nt=1, dt=0.0, i0=0.8)
+
+    with pytest.raises(ValueError):
+        solver.solve(c, initial_state=np.array([1, 0, -1]))


### PR DESCRIPTION
- added SparsePBitLMTemporalMemory that is an extension of SparsePBitLM with temporal memory
- added Demo 3 that shows higher results because of SparsePBitLMTemporalMemory 
- added support for #117 (initial_state in CaSuDaSolver); useful as a general solver feature, but it does not currently improve the LM results
Closes #117 