### PR TITLE
Add GibbsSolver: asynchronous single-p-bit Gibbs sampler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**p-kit** is a Python library (IBM, BSD-3-Clause) for simulating probabilistic circuits using p-bits that fluctuate between -1 and +1. It implements two frameworks:
+- **PSL (Probabilistic Spin Logic)**: Invertible classical logic via Gibbs sampling — logic gates map to probabilistic spin logic gates.
+- **PAOA (Probabilistic Approximate Optimization Algorithms)**: Probabilistic analog of QAOA for combinatorial optimization.
+
+## Commands
+
+```bash
+pip install .           # Install base package
+pip install .[tests]    # Include test deps (pytest, seaborn, flake8)
+
+pytest                  # Run all tests
+pytest tests/test_core.py::test_canary  # Run a single test
+flake8 p_kit tests      # Lint
+```
+
+CI runs tests on Python 3.10/3.11 across Ubuntu, macOS, Windows (`python-app.yml`), and validates all examples execute without error (`run_examples.yml`).
+
+## Architecture
+
+### Decorator-based circuit API (`p_kit.psl`)
+
+The entry point is a **decorator API** in `p_kit/psl/decorators.py`:
+
+- `@pcircuit(n_pbits)`: Transforms a class into a circuit by injecting `J` (n×n coupling matrix) and `h` (n×1 bias vector) management, plus port tracking. The J/h matrices are typically defined as class-level `np.ndarray` attributes.
+- `@module`: Transforms a class into a container of circuit instances with `synthesize()` support. Records all child circuit instances and their port connections, then merges their local J/h matrices into a global representation.
+
+**`Port`** (`p_kit/psl/port.py`): Represents a circuit's I/O terminal. Ports are connected with `port.connect(other_port, ConnectionType)`:
+- `NoCopyConnection`: Shared global index — no extra coupling terms
+- `VanillaCopyConnection`: Adds a weight-1 coupling between the two p-bits
+- `WeightedCopyConnection`: Same with custom weight
+
+**`ModuleContext`** (`p_kit/psl/context.py`): Manages global index assignment during synthesis. `synthesize(format='sparse'|'dense')` returns the merged J and h across all registered instances.
+
+### Solvers (`p_kit/solver/`)
+
+**`Solver`** (base): Parameters are `Nt` (timesteps), `dt`, `i0` (correlation strength 0–1), optional `expected_mean` and `seed`. Subclasses implement `solve(circuit)`.
+
+**`CaSuDaSolver`**: Primary solver. At each step, computes input currents `I = i0 * (m @ J + h)`, then updates magnetization `m` stochastically. Returns `(all_I, all_m, E)` — full `Nt × n_pbits` trajectories for currents and magnetizations, plus energy vector.
+
+**`GibbsSolver`**: Asynchronous single-p-bit-per-step Gibbs sampler (contrast with CaSuDaSolver's synchronous, vectorized update). Resamples exactly one randomly chosen p-bit per timestep via a sigmoid acceptance probability, conditioned on the current state of all others. Same constructor and return contract as `CaSuDaSolver` (drop-in swap), but converges slower — useful as a textbook-correct reference to validate CaSuDa's synchronous approximation against.
+
+**Annealing** (`p_kit/solver/annealing.py`): `constant` and `linear` schedules that modify `i0` over time. `execute(solver, circuit, annealing, n_shots, n_last_samples, n_jobs)` runs the solver multiple times in parallel (via `joblib`) and collects final samples.
+
+### Gate library (`p_kit/psl/gates/`)
+
+Pre-built `@pcircuit` classes with hardcoded J/h matrices: `ANDGate`, `ORGate` (3 p-bits each), `FullAdder` (5 p-bits). These are the primary reference for how to encode logic as probabilistic couplings.
+
+### Visualization (`p_kit/visualization/`)
+
+`histplot`, `energyplot`, `vin_vout`, `heatmap`, `plot3d`, `visualize_tsp_route`. Most functions take the solver output arrays directly.
+
+### Library (`p_kit/library/`)
+
+Higher-level algorithms built on top of the framework — currently `p_kit.library.tsp` for the Traveling Salesman Problem.
+
+## Test structure
+
+Tests in `tests/` use `conftest.py` fixtures (e.g., `rndstate` for seeded random). Visualization tests use `@requires_matplotlib` / `@requires_seaborn` decorators (defined in conftest) to skip when optional deps are absent. The test suite is intentionally lightweight — `test_canary` is `assert True`.
+
+## Key dependency versions
+
+`numpy<2.3`, `scipy==1.15.3`, `cython==3.2.4`, `cvxpy==1.7.5`, `matplotlib==3.10.9`. Python >=3.10 required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ The entry point is a **decorator API** in `p_kit/psl/decorators.py`:
 
 **`CaSuDaSolver`**: Primary solver. At each step, computes input currents `I = i0 * (m @ J + h)`, then updates magnetization `m` stochastically. Returns `(all_I, all_m, E)` — full `Nt × n_pbits` trajectories for currents and magnetizations, plus energy vector.
 
-**`GibbsSolver`**: Asynchronous single-p-bit-per-step Gibbs sampler (contrast with CaSuDaSolver's synchronous, vectorized update). Resamples exactly one randomly chosen p-bit per timestep via a sigmoid acceptance probability, conditioned on the current state of all others. Same constructor and return contract as `CaSuDaSolver` (drop-in swap), but converges slower — useful as a textbook-correct reference to validate CaSuDa's synchronous approximation against.
+**`GibbsSolver`**: Asynchronous single-p-bit-per-sweep Gibbs sampler (contrast with CaSuDaSolver's synchronous, vectorized update). Each `Nt` tick is a full sweep: every p-bit is resampled once, in a random order, via a sigmoid heat-bath probability conditioned on the current state of all others — this makes `Nt`/`i0` comparable to `CaSuDaSolver`'s (both update every p-bit once per tick). Same constructor and return contract as `CaSuDaSolver` (drop-in swap), but mixes slower (sequential vs. parallel updates within a tick) — useful as a textbook-correct reference to validate CaSuDa's synchronous approximation against.
 
 **Annealing** (`p_kit/solver/annealing.py`): `constant` and `linear` schedules that modify `i0` over time. `execute(solver, circuit, annealing, n_shots, n_last_samples, n_jobs)` runs the solver multiple times in parallel (via `joblib`) and collects final samples.
 

--- a/examples/gibbs_and_gate.py
+++ b/examples/gibbs_and_gate.py
@@ -1,0 +1,33 @@
+"""Module for pipelines."""
+
+from p_kit.psl import PCircuit
+from p_kit.solver.gibbs_solver import GibbsSolver
+from p_kit.visualization import histplot, energyplot, vin_vout
+import numpy as np
+
+
+c = PCircuit(3)
+# c.set_weight(0, 1, -2)
+# c.set_weight(0, 2, -2)
+# c.set_weight(1, 2, 1)
+c.J = np.array([[0, -1, 2], [-1, 0, 2], [2, 2, 0]])
+
+# Here, you can change biases.
+# A high bias clamp a p-bit toward 1/0.
+# (depending on the sign of the bias)
+c.h = np.array([1, 1, -2])
+
+# Asynchronous single-p-bit-per-step Gibbs sampling converges slower than
+# CaSuDa's synchronous update, so use a larger Nt to well-sample the AND
+# gate's stationary distribution. dt is kept for interface parity even
+# though GibbsSolver does not use it.
+solver = GibbsSolver(Nt=30000, dt=0.1667, i0=0.8)
+
+input, output, energy = solver.solve(c)
+
+histplot(output)
+
+energyplot(output, energy)
+
+# function characteristic of p_bit 2
+vin_vout(input, output, p_bit=2)

--- a/examples/gibbs_and_gate.py
+++ b/examples/gibbs_and_gate.py
@@ -17,11 +17,12 @@ c.J = np.array([[0, -1, 2], [-1, 0, 2], [2, 2, 0]])
 # (depending on the sign of the bias)
 c.h = np.array([1, 1, -2])
 
-# Asynchronous single-p-bit-per-step Gibbs sampling converges slower than
-# CaSuDa's synchronous update, so use a larger Nt to well-sample the AND
-# gate's stationary distribution. dt is kept for interface parity even
-# though GibbsSolver does not use it.
-solver = GibbsSolver(Nt=30000, dt=0.1667, i0=0.8)
+# Nt counts sweeps (each sweep updates every p-bit once, sequentially, in
+# a random order), matching CaSuDaSolver's convention that Nt updates
+# every p-bit once per step — so the same Nt/i0 used for CaSuDaSolver
+# works here too. dt is kept for interface parity even though GibbsSolver
+# does not use it.
+solver = GibbsSolver(Nt=10000, dt=0.1667, i0=0.8)
 
 input, output, energy = solver.solve(c)
 

--- a/p_kit/solver/__init__.py
+++ b/p_kit/solver/__init__.py
@@ -1,4 +1,5 @@
 from .csd_solver import CaSuDaSolver
+from .gibbs_solver import GibbsSolver
 from . import annealing
 
-__all__ = ["CaSuDaSolver", "annealing"]
+__all__ = ["CaSuDaSolver", "GibbsSolver", "annealing"]

--- a/p_kit/solver/gibbs_solver.py
+++ b/p_kit/solver/gibbs_solver.py
@@ -1,0 +1,86 @@
+from p_kit.psl.p_circuit import PCircuit
+from p_kit.solver.annealing import constant
+from .base_solver import Solver
+
+
+class GibbsSolver(Solver):
+    """Asynchronous single-p-bit-per-step Gibbs sampler for Ising-type models.
+
+    S. Geman and D. Geman, 'Stochastic relaxation, Gibbs distributions, and
+    the Bayesian restoration of images', IEEE Transactions on Pattern
+    Analysis and Machine Intelligence, vol. PAMI-6, no. 6, pp. 721-741, 1984,
+    doi: 10.1109/TPAMI.1984.4767596.
+
+    Unlike CaSuDaSolver's synchronous, vectorized update of all p-bits at
+    once, this solver resamples exactly one p-bit per timestep conditioned
+    on the current state of all the others — the textbook asynchronous
+    Gibbs/Metropolis-style update for PSL/Ising models. It is slower but
+    provides a reference implementation to validate CaSuDa's synchronous
+    approximation against.
+    """
+
+    # `dt` and `tau` are accepted (via the inherited Solver.__init__) only
+    # for interface parity with CaSuDaSolver, so this solver is a drop-in
+    # swap. They are not used here: Gibbs sampling uses a direct sigmoid
+    # acceptance probability, not CaSuDa's leaky flip-rate model.
+
+    def solve(self, c: PCircuit, annealing_func=constant, n_shots=1):
+        """Run the asynchronous Gibbs p-bit sampler.
+
+        Returns
+        -------
+        ``n_shots == 1`` -> ``(all_I, all_m, E)``
+        ``n_shots > 1``  -> ``all_m``
+        """
+
+        xp = self.xp
+        n_pbits = c.n_pbits
+
+        J = xp.asarray(c.J)
+        h = xp.asarray(c.h).flatten()  # Ensure h is 1D for proper broadcasting
+
+        # m is (n_shots, n_pbits) — works for n_shots=1 too
+        m = xp.sign(0.5 - self.random((n_shots, n_pbits)))
+
+        # Unscaled local field per shot, kept in sync with m via a cheap
+        # incremental update on each single-p-bit flip (see below) rather
+        # than recomputing the full m @ J product every step — the point of
+        # an asynchronous single-p-bit sampler is that a step touches only
+        # one p-bit's worth of coupling, not the whole circuit's.
+        field = m @ J + h
+
+        all_m = xp.zeros((self.Nt, n_shots, n_pbits))
+        all_I = xp.zeros((self.Nt, n_pbits))
+        E = xp.zeros(self.Nt)
+
+        for run in range(self.Nt):
+            idx = int(self._random_gen.integers(0, n_pbits))
+            a = annealing_func(self, run)
+            # Pre-update field: the drive that decides this step's flip,
+            # recorded as all_I[run] to match CaSuDaSolver's convention that
+            # all_I[run] is the current which produced all_m[run].
+            I_full = a * field
+            p = 1 / (1 + xp.exp(-2 * I_full[:, idx]))
+            u = self.random(n_shots)
+            new = xp.where(u < p, 1.0, -1.0)
+            delta = new - m[:, idx]
+            m[:, idx] = new
+            # J is symmetric, so column idx == row idx; flipping p-bit idx
+            # by `delta` shifts every other p-bit's field by delta * J[idx].
+            field = field + delta[:, None] * J[idx, :]
+
+            all_I[run] = I_full[0]
+            all_m[run] = m
+            E[run] = self.i0 * (xp.dot(m[0], h) +
+                                0.5 * xp.dot(xp.dot(m[0], J), m[0]))
+
+        if self.device == 'cuda':
+            all_I, all_m, E = all_I.get(), all_m.get(), E.get()
+
+        if n_shots == 1:
+            return all_I, all_m[:, 0, :], E
+        return all_m
+
+    def copy(self):
+        return GibbsSolver(self.Nt, self.dt, self.i0, self.expected_mean,
+                           self.seed, self.device, self.tau)

--- a/p_kit/solver/gibbs_solver.py
+++ b/p_kit/solver/gibbs_solver.py
@@ -4,7 +4,7 @@ from .base_solver import Solver
 
 
 class GibbsSolver(Solver):
-    """Asynchronous single-p-bit-per-step Gibbs sampler for Ising-type models.
+    """Asynchronous single-p-bit-per-sweep Gibbs sampler for Ising-type models.
 
     S. Geman and D. Geman, 'Stochastic relaxation, Gibbs distributions, and
     the Bayesian restoration of images', IEEE Transactions on Pattern
@@ -12,11 +12,19 @@ class GibbsSolver(Solver):
     doi: 10.1109/TPAMI.1984.4767596.
 
     Unlike CaSuDaSolver's synchronous, vectorized update of all p-bits at
-    once, this solver resamples exactly one p-bit per timestep conditioned
-    on the current state of all the others — the textbook asynchronous
-    Gibbs/Metropolis-style update for PSL/Ising models. It is slower but
-    provides a reference implementation to validate CaSuDa's synchronous
-    approximation against.
+    once, this solver resamples each p-bit exactly once per sweep, in a
+    random order, conditioned on the current state of all the others — the
+    textbook asynchronous Gibbs/heat-bath update for PSL/Ising models.
+
+    ``Nt`` counts *sweeps*, not individual single-p-bit updates: each sweep
+    performs ``n_pbits`` sequential updates internally, but only the
+    post-sweep state is recorded. This mirrors CaSuDaSolver's convention
+    that every ``Nt`` tick updates every p-bit once, so the same ``Nt``
+    (and the same ``i0``) represents comparable computational work and
+    comparable mixing between the two solvers. It is slower to mix than
+    CaSuDa's fully parallel update (sequential vs. synchronous within a
+    sweep), but provides a reference implementation to validate CaSuDa's
+    synchronous approximation against.
     """
 
     # `dt` and `tau` are accepted (via the inherited Solver.__init__) only
@@ -26,6 +34,10 @@ class GibbsSolver(Solver):
 
     def solve(self, c: PCircuit, annealing_func=constant, n_shots=1):
         """Run the asynchronous Gibbs p-bit sampler.
+
+        Each of the ``Nt`` steps is a full sweep: every p-bit is resampled
+        exactly once, in a random order, using a heat-bath/Gibbs
+        probability conditioned on the others' current state.
 
         Returns
         -------
@@ -44,9 +56,9 @@ class GibbsSolver(Solver):
 
         # Unscaled local field per shot, kept in sync with m via a cheap
         # incremental update on each single-p-bit flip (see below) rather
-        # than recomputing the full m @ J product every step — the point of
-        # an asynchronous single-p-bit sampler is that a step touches only
-        # one p-bit's worth of coupling, not the whole circuit's.
+        # than recomputing the full m @ J product on every one of the
+        # n_pbits flips within a sweep. This also lets the energy below be
+        # computed in O(n_pbits) instead of the O(n_pbits^2) of m @ J @ m.
         field = m @ J + h
 
         all_m = xp.zeros((self.Nt, n_shots, n_pbits))
@@ -54,25 +66,28 @@ class GibbsSolver(Solver):
         E = xp.zeros(self.Nt)
 
         for run in range(self.Nt):
-            idx = int(self._random_gen.integers(0, n_pbits))
             a = annealing_func(self, run)
-            # Pre-update field: the drive that decides this step's flip,
-            # recorded as all_I[run] to match CaSuDaSolver's convention that
-            # all_I[run] is the current which produced all_m[run].
-            I_full = a * field
-            p = 1 / (1 + xp.exp(-2 * I_full[:, idx]))
-            u = self.random(n_shots)
-            new = xp.where(u < p, 1.0, -1.0)
-            delta = new - m[:, idx]
-            m[:, idx] = new
-            # J is symmetric, so column idx == row idx; flipping p-bit idx
-            # by `delta` shifts every other p-bit's field by delta * J[idx].
-            field = field + delta[:, None] * J[idx, :]
+            # Pre-sweep field: the drive that seeds this step's transition,
+            # recorded as all_I[run] to match CaSuDaSolver's convention
+            # that all_I[run] is the current which produced all_m[run].
+            all_I[run] = (a * field)[0]
 
-            all_I[run] = I_full[0]
+            for idx in self._random_gen.permutation(n_pbits):
+                idx = int(idx)
+                p = 1 / (1 + xp.exp(-2 * a * field[:, idx]))
+                u = self.random(n_shots)
+                new = xp.where(u < p, 1.0, -1.0)
+                delta = new - m[:, idx]
+                m[:, idx] = new
+                # J is symmetric, so column idx == row idx; flipping p-bit
+                # idx by `delta` shifts every p-bit's field by delta * J[idx].
+                field = field + delta[:, None] * J[idx, :]
+
             all_m[run] = m
-            E[run] = self.i0 * (xp.dot(m[0], h) +
-                                0.5 * xp.dot(xp.dot(m[0], J), m[0]))
+            # E = i0*(m@h + 0.5*m@J@m); since field = m@J+h, m@J@m reduces
+            # to (field-h)@m, so E = 0.5*i0*m@(h+field) — O(n_pbits) using
+            # the field already maintained above, no O(n_pbits^2) matmul.
+            E[run] = 0.5 * self.i0 * xp.dot(m[0], h + field[0])
 
         if self.device == 'cuda':
             all_I, all_m, E = all_I.get(), all_m.get(), E.get()

--- a/tests/test_gibbs_solver.py
+++ b/tests/test_gibbs_solver.py
@@ -1,0 +1,114 @@
+"""Tests for GibbsSolver, the asynchronous single-p-bit-per-step Gibbs
+sampler.
+
+Contrasts with CaSuDaSolver (synchronous, vectorized update of all p-bits
+at once): GibbsSolver resamples exactly one randomly chosen p-bit per
+timestep, conditioned on the current state of all the others. These tests
+cover the return contract (mirrors CaSuDaSolver's default, no-bias_func
+path), the asynchronous-update invariant, seeded reproducibility,
+energy-formula consistency, and functional correctness against AND's
+truth table.
+"""
+import numpy as np
+from p_kit.psl.gates import ANDGate
+from p_kit.solver import GibbsSolver
+
+
+# ── Return contract ──────────────────────────────────────────────────────
+
+def test_return_contract_single_shot():
+    """n_shots=1 returns the (all_I, all_m, E) 3-tuple; all_m is +/-1."""
+    gate = ANDGate()
+    solver = GibbsSolver(Nt=200, dt=0.1667, i0=0.9, seed=42)
+    out = solver.solve(gate)
+
+    assert isinstance(out, tuple) and len(out) == 3
+    all_I, all_m, E = out
+    assert all_m.shape == (200, 3)
+    assert set(np.unique(all_m)).issubset({-1.0, 1.0})
+
+
+def test_return_contract_multi_shot():
+    """n_shots>1 returns a bare array (no tuple), shape (Nt, n_shots, n)."""
+    gate = ANDGate()
+    solver = GibbsSolver(Nt=200, dt=0.1667, i0=0.9, seed=42)
+    out = solver.solve(gate, n_shots=4)
+
+    assert not isinstance(out, tuple)
+    assert out.shape == (200, 4, 3)
+    assert set(np.unique(out)).issubset({-1.0, 1.0})
+
+
+# ── Asynchronous-update property ─────────────────────────────────────────
+
+def test_asynchronous_update_changes_at_most_one_pbit_per_step():
+    """Exactly one p-bit is resampled per step, so consecutive states
+    differ in at most one coordinate (the resampled p-bit's new draw may
+    coincide with its old value, so zero coordinates is possible too, but
+    never more than one).
+    """
+    gate = ANDGate()
+    solver = GibbsSolver(Nt=400, dt=0.1667, i0=0.9, seed=42)
+    _, all_m, _ = solver.solve(gate)
+
+    diffs = np.count_nonzero(all_m[:-1] != all_m[1:], axis=1)
+    assert np.all(diffs <= 1)
+    # Sanity: over 400 steps on a 3-p-bit circuit, at least some steps
+    # should actually flip a bit (else the property is vacuously true).
+    assert np.any(diffs == 1)
+
+
+# ── Seeded reproducibility ────────────────────────────────────────────────
+
+def test_seeded_reproducibility():
+    """Two solvers with the same seed produce bit-identical trajectories."""
+    gate = ANDGate()
+    a = GibbsSolver(Nt=300, dt=0.1667, i0=0.9, seed=7).solve(gate.copy())
+    b = GibbsSolver(Nt=300, dt=0.1667, i0=0.9, seed=7).solve(gate.copy())
+
+    assert np.array_equal(a[1], b[1])
+    assert np.array_equal(a[0], b[0])
+    assert np.array_equal(a[2], b[2])
+
+
+# ── Energy formula consistency ────────────────────────────────────────────
+
+def test_energy_matches_documented_formula():
+    """E is reconstructible from all_m via i0*(m@h + 0.5*m@J@m) per step."""
+    gate = ANDGate()
+    solver = GibbsSolver(Nt=300, dt=0.1667, i0=0.9, seed=11)
+    _, all_m, E = solver.solve(gate)
+
+    h = gate.h.flatten()
+    expected = solver.i0 * (
+        all_m @ h + 0.5 * np.einsum('ti,ij,tj->t', all_m, gate.J, all_m)
+    )
+    assert np.allclose(E, expected)
+
+
+# ── Functional correctness (truth table) ──────────────────────────────────
+
+def test_and_gate_truth_table():
+    """AND gate produces the correct truth table under the Gibbs sampler."""
+    gate = ANDGate()
+    solver = GibbsSolver(Nt=20000, dt=0.1667, i0=0.9, seed=42)
+
+    test_cases = [
+        ([-1, -1], -1),  # 0 AND 0 = 0
+        ([-1, 1], -1),   # 0 AND 1 = 0
+        ([1, -1], -1),   # 1 AND 0 = 0
+        ([1, 1], 1),     # 1 AND 1 = 1
+    ]
+
+    for inputs, expected_output in test_cases:
+        gate.h[0] = inputs[0] * 10
+        gate.h[1] = inputs[1] * 10
+        _, output, _ = solver.solve(gate)
+
+        # Output is at index 2 (order: input1, input2, output).
+        output_states = output[:, 2]
+        most_common = 1 if np.mean(output_states) > 0 else -1
+        assert most_common == expected_output, (
+            f"AND({inputs[0]}, {inputs[1]}) expected {expected_output}, "
+            f"got {most_common}"
+        )

--- a/tests/test_gibbs_solver.py
+++ b/tests/test_gibbs_solver.py
@@ -39,23 +39,25 @@ def test_return_contract_multi_shot():
     assert set(np.unique(out)).issubset({-1.0, 1.0})
 
 
-# ── Asynchronous-update property ─────────────────────────────────────────
+# ── Sweep semantics ───────────────────────────────────────────────────────
 
-def test_asynchronous_update_changes_at_most_one_pbit_per_step():
-    """Exactly one p-bit is resampled per step, so consecutive states
-    differ in at most one coordinate (the resampled p-bit's new draw may
-    coincide with its old value, so zero coordinates is possible too, but
-    never more than one).
+def test_nt_counts_full_sweeps_not_single_flips():
+    """Each Nt step is a full sweep (every p-bit resampled once, in a
+    random order), not a single-p-bit update — so consecutive recorded
+    states may differ in up to n_pbits coordinates. This also rules out a
+    regression to a single-flip-per-step design, which would make this
+    solver's Nt incomparable to CaSuDaSolver's (where one Nt tick also
+    updates every p-bit once).
     """
     gate = ANDGate()
-    solver = GibbsSolver(Nt=400, dt=0.1667, i0=0.9, seed=42)
+    solver = GibbsSolver(Nt=200, dt=0.1667, i0=0.9, seed=42)
     _, all_m, _ = solver.solve(gate)
 
     diffs = np.count_nonzero(all_m[:-1] != all_m[1:], axis=1)
-    assert np.all(diffs <= 1)
-    # Sanity: over 400 steps on a 3-p-bit circuit, at least some steps
-    # should actually flip a bit (else the property is vacuously true).
-    assert np.any(diffs == 1)
+    assert np.all(diffs <= gate.n_pbits)
+    # With n_pbits=3 and 200 sweeps, some sweeps should flip more than one
+    # p-bit — proof this is sweeping all p-bits, not resampling just one.
+    assert np.any(diffs > 1)
 
 
 # ── Seeded reproducibility ────────────────────────────────────────────────


### PR DESCRIPTION
Complements CaSuDaSolver's synchronous vectorized update with a textbook asynchronous single-p-bit-per-step Gibbs sampler, useful as a reference implementation to validate CaSuDa's synchronous approximation against. Drop-in compatible constructor and return contract; local field is maintained incrementally per flip rather than recomputed via a full matmul each step.