### PR TITLE
Added a new Torch CaSuDa solver and LM Demo 4

### DIFF
--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -44,9 +44,11 @@ The sparse p-bit architecture is intended to be hardware-friendly: the same mode
 
 # Files
 
-* `llm_model.py` — Sparse p-bit reservoir language model proof of concept. Uses a p-kit recurrent reservoir, p-kit ReLU block, and NumPy ridge-regression readout.
-* `llm_demo_001.py` — Basic p-kit language-model demo showing training, next-character generation, sparsity, and p-kit execution.
-* `llm_demo_002.py` — Comparison between `SparsePBitLM` and a tiny Hugging Face GPT trained from scratch on the same corpus and vocabulary. Compares accuracy, perplexity, training time, trainable parameters, and generated text.
+* `llm_model.py` - Sparse p-bit reservoir language model proof of concept. Uses a p-kit recurrent reservoir, p-kit ReLU block, and NumPy ridge-regression readout.
+* `llm_demo_001.py` - Basic p-kit language-model demo showing training, next-character generation, sparsity, and p-kit execution.
+* `llm_demo_002.py` - Comparison between `SparsePBitLM` and a tiny Hugging Face GPT trained from scratch on the same corpus and vocabulary. Compares accuracy, perplexity, training time, trainable parameters, and generated text.
+* `llm_demo_003.py` - Comparison between `SparsePBitLMTemporalMemory` and the tiny GPT baseline. Shows the accuracy improvement obtained with explicit reservoir-state history while keeping fewer trainable parameters and no backpropagation through the p-bit reservoir.
+* `llm_demo_004.py` - Compares a LM over p-kit using several Solvers and the GPT baseline. Shows that execution can be on both CPU and GPU.
 
 # Future research
 

--- a/examples/llm/llm_demo_004.py
+++ b/examples/llm/llm_demo_004.py
@@ -1,0 +1,182 @@
+"""
+llm_demo_004.py
+
+Compares SparsePBitLMTemporalMemory using:
+  1. CaSuDaSolver
+  2. TorchCaSuDaSolver
+  3. Tiny GPT baseline
+on both CPU and GPU (if available)
+
+GPU support:
+     CaSuDaSolver => GPU through CuPy/CUDA
+TorchCaSuDaSolver => GPU through PyTorch CUDA
+Tiny GPT baseline => GPU through PyTorch CUDA
+
+Best p-kit configuration:
+  history_size=8
+  memory_scale=0.35
+  use_initial_state=False
+  
+Results
+                Model  Trainable     Acc      PPL     Time
+     CaSuDaSolver CPU      22176   0.793   12.155    1.97s
+TorchCaSuDaSolver CPU      22176   0.756   12.125    9.24s
+              GPT CPU     103488   0.829    2.294    2.07s
+           
+    TorchCaSuDaSolver is currently slower on CPU than CaSuDaSolver, but it 
+    might get faster once we switch to a bigger p-kit LM and CUDA.
+
+"""
+
+import math,time
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+from transformers import GPT2Config,GPT2LMHeadModel
+
+from llm_model import SparsePBitLMTemporalMemory
+from p_kit.solver.csd_solver import CaSuDaSolver
+from p_kit.solver.torch_csd_solver import TorchCaSuDaSolver
+
+TRAIN="""
+the cat sat on the mat.
+the dog sat by the door.
+the cat looked at the dog.
+the dog looked at the cat.
+the cat walked to the door.
+the dog walked to the mat.
+the small robot saw the cat.
+the small robot saw the dog.
+the robot moved to the door.
+the robot moved to the mat.
+"""*20
+
+TEST="""
+the cat moved to the door.
+the dog moved to the mat.
+the robot looked at the cat.
+"""
+
+VOCAB=sorted(set(TRAIN)); C2I={c:i for i,c in enumerate(VOCAB)}
+def encode(text): return [C2I[c] for c in text]
+
+try:
+    import cupy as cp
+    CUPY_CUDA=cp.cuda.runtime.getDeviceCount()>0
+except Exception:
+    cp=None
+    CUPY_CUDA=False
+
+TORCH_CUDA=torch.cuda.is_available()
+
+def evaluate_pkit(model):
+    model.reset(); correct=total=0; nll=0
+    for current,target in zip(TEST[:-1],TEST[1:]):
+        p=model.next_char_probabilities(current,temperature=1.0)
+        tid=model.char_to_id[target]
+        correct+=int(np.argmax(p)==tid)
+        nll-=math.log(max(float(p[tid]),1e-12)); total+=1
+    return correct/total,math.exp(nll/total)
+
+def make_pkit():
+    return SparsePBitLMTemporalMemory(
+        n_pbits=128,degree=8,input_fanout=16,
+        recurrent_scale=.40,input_scale=1.4,
+        memory_scale=.35,history_size=8,
+        use_initial_state=False,seed=7)
+
+def train_pkit(model,sync=None):
+    if sync: sync()
+    start=time.perf_counter()
+    model.fit(TRAIN,washout=30,ridge=.05)
+    if sync: sync()
+    elapsed=time.perf_counter()-start
+    acc,ppl=evaluate_pkit(model)
+    return acc,ppl,elapsed
+
+def make_gpt(context=32,device="cpu"):
+    model=GPT2LMHeadModel(GPT2Config(
+        vocab_size=len(VOCAB),n_positions=context,n_ctx=context,
+        n_embd=64,n_layer=2,n_head=2,
+        resid_pdrop=0,embd_pdrop=0,attn_pdrop=0,
+        bos_token_id=None,eos_token_id=None))
+    return model.to(device)
+
+def train_gpt(device="cpu",context=32,epochs=15):
+    ids=encode(TRAIN)
+    blocks=[torch.tensor(ids[i:i+context]) for i in range(0,len(ids)-context,context//2)]
+    model=make_gpt(context,device)
+    loader=DataLoader(blocks,batch_size=16,shuffle=True)
+    opt=torch.optim.AdamW(model.parameters(),lr=3e-3)
+
+    if device=="cuda": torch.cuda.synchronize()
+    start=time.perf_counter(); model.train()
+
+    for _ in range(epochs):
+        for batch in loader:
+            batch=batch.to(device)
+            opt.zero_grad()
+            loss=model(input_ids=batch,labels=batch).loss
+            loss.backward(); opt.step()
+
+    if device=="cuda": torch.cuda.synchronize()
+    return model,time.perf_counter()-start
+
+def evaluate_gpt(model,device="cpu",context=32):
+    ids=encode(TEST); correct=total=0; nll=0; model.eval()
+    with torch.no_grad():
+        for t in range(1,len(ids)):
+            x=torch.tensor(ids[max(0,t-context):t],device=device).unsqueeze(0)
+            p=torch.softmax(model(x).logits[0,-1],dim=-1)
+            correct+=int(torch.argmax(p).item()==ids[t])
+            nll-=math.log(max(float(p[ids[t]].item()),1e-12)); total+=1
+    return correct/total,math.exp(nll/total)
+
+def add_pkit(results,name,solver_cls,device,sync=None,**kwargs):
+    print(f"Training {name}...")
+    model=make_pkit()
+    model.reservoir_solver=solver_cls(
+        Nt=10,dt=.1667,i0=.8,seed=7,device=device,**kwargs)
+    model.relu_solver=solver_cls(
+        Nt=10,dt=.1667,i0=.8,seed=8,device=device,**kwargs)
+    acc,ppl,t=train_pkit(model,sync)
+    results.append((name,model.readout.size,acc,ppl,t))
+
+def add_gpt(results,name,device):
+    print(f"Training {name}...")
+    torch.manual_seed(7)
+    if device=="cuda": torch.cuda.manual_seed_all(7)
+    model,t=train_gpt(device)
+    acc,ppl=evaluate_gpt(model,device)
+    results.append((name,sum(p.numel() for p in model.parameters()),acc,ppl,t))
+
+def main():
+    np.random.seed(7); torch.manual_seed(7)
+    results=[]
+    
+    add_pkit(results, "CaSuDaSolver CPU", CaSuDaSolver, "cpu")
+    add_pkit(results, "TorchCaSuDaSolver CPU", TorchCaSuDaSolver, "cpu", cache_J=True)
+    add_gpt(results, "GPT CPU", "cpu")
+
+    if CUPY_CUDA:
+        add_pkit(
+            results, "CaSuDaSolver CUDA", CaSuDaSolver, "cuda",
+            sync=lambda: cp.cuda.Stream.null.synchronize())
+    
+    if TORCH_CUDA:
+        add_pkit(
+            results, "TorchCaSuDaSolver CUDA", TorchCaSuDaSolver, "cuda",
+            sync=torch.cuda.synchronize, cache_J=True, compile=True)
+        add_gpt(results, "GPT CUDA", "cuda")
+
+    print("\nCUDA availability")
+    print(f"CuPy:   {CUPY_CUDA}")
+    print(f"PyTorch:{TORCH_CUDA}")
+
+    print("\nResults")
+    print(f"{'Model':>20} {'Trainable':>10} {'Acc':>7} {'PPL':>8} {'Time':>8}")
+    for name,p,acc,ppl,t in results:
+        print(f"{name:>20} {p:10d} {acc:7.3f} {ppl:8.3f} {t:7.2f}s")
+
+if __name__=="__main__":
+    main()

--- a/examples/llm/llm_demo_004.py
+++ b/examples/llm/llm_demo_004.py
@@ -19,9 +19,9 @@ Best p-kit configuration:
   
 Results
                 Model  Trainable     Acc      PPL     Time
-     CaSuDaSolver CPU      22176   0.793   12.155    1.97s
-TorchCaSuDaSolver CPU      22176   0.756   12.125    9.24s
-              GPT CPU     103488   0.829    2.294    2.07s
+     CaSuDaSolver CPU      22176   0.793   12.155    1.98s
+TorchCaSuDaSolver CPU      22176   0.756   12.125   10.48s
+              GPT CPU     103488   0.829    2.294    2.43s
            
     TorchCaSuDaSolver is currently slower on CPU than CaSuDaSolver, but it 
     might get faster once we switch to a bigger p-kit LM and CUDA.
@@ -155,7 +155,7 @@ def main():
     results=[]
     
     add_pkit(results, "CaSuDaSolver CPU", CaSuDaSolver, "cpu")
-    add_pkit(results, "TorchCaSuDaSolver CPU", TorchCaSuDaSolver, "cpu", cache_J=True)
+    add_pkit(results, "TorchCaSuDaSolver CPU", TorchCaSuDaSolver, "cpu")
     add_gpt(results, "GPT CPU", "cpu")
 
     if CUPY_CUDA:
@@ -166,7 +166,7 @@ def main():
     if TORCH_CUDA:
         add_pkit(
             results, "TorchCaSuDaSolver CUDA", TorchCaSuDaSolver, "cuda",
-            sync=torch.cuda.synchronize, cache_J=True, compile=True)
+            sync=torch.cuda.synchronize, compile=True)
         add_gpt(results, "GPT CUDA", "cuda")
 
     print("\nCUDA availability")

--- a/p_kit/solver/torch_csd_solver.py
+++ b/p_kit/solver/torch_csd_solver.py
@@ -13,14 +13,13 @@ NOTES:
   - The solver keeps the same PCircuit, J/h model and CaSuDa dynamics.
   - It is intended mainly as an accelerator-oriented alternative backend.
   - For small p-bit models, PyTorch CPU can be slower than the NumPy solver.
-  - GPU/accelerator benefits are expected mainly for larger workloads.
-  - cache_J=True improves performance when J remains fixed.
-  - If c.J is modified while cache_J=True, call solver.clear_cache().
+  - GPU benefits are expected mainly for larger workloads.
+  - cache_J is currently disabled because PCircuit.J may be modified in place.
   - compile=True may improve accelerator performance but adds compilation overhead.
-  - device="spyre" requires torch-spyre and access to compatible Spyre hardware/runtime.
+  - Spyre support is currently disabled pending integration with the common
+    annealing backend.
   - PyTorch and NumPy solvers use different random generators, so stochastic
     trajectories and final results are not expected to be identical.
-
 """
 
 import numpy as np
@@ -31,227 +30,149 @@ from p_kit.solver.annealing import constant
 from .base_solver import Solver
 
 
-def _single_kernel(m, J, h, anneal, rnd, dt, threshold, i0):
-    Nt, n_pbits = rnd.shape
-    all_m = torch.empty((Nt, n_pbits), dtype=m.dtype, device=m.device)
-    all_I = torch.empty_like(all_m)
-    E = torch.empty(Nt, dtype=m.dtype, device=m.device)
+def _single_kernel(m,J,h,anneal,rnd,dt,threshold,i0):
+    Nt,n=rnd.shape
+    all_m=torch.empty((Nt,n),dtype=m.dtype,device=m.device)
+    all_I=torch.empty_like(all_m)
+    E=torch.empty(Nt,dtype=m.dtype,device=m.device)
 
     for run in range(Nt):
-        field = m @ J
-
+        field=m@J
         if run:
-            E[run-1] = i0 * (
-                torch.dot(m, h) + 0.5 * torch.dot(field, m)
-            )
+            E[run-1]=i0*(torch.dot(m,h)+.5*torch.dot(field,m))
+        I=anneal[run]*(field+h)
+        s=torch.exp(-dt*torch.exp(-m*(I+threshold)))
+        m=m*torch.sign(s-rnd[run])
+        all_m[run]=m; all_I[run]=I
 
-        I = anneal[run] * (field + h)
-        s = torch.exp(-dt * torch.exp(-m * (I + threshold)))
-        m = m * torch.sign(s - rnd[run])
-
-        all_m[run] = m
-        all_I[run] = I
-
-    field = m @ J
-    E[-1] = i0 * (
-        torch.dot(m, h) + 0.5 * torch.dot(field, m)
-    )
-
-    return all_I, all_m, E
+    field=m@J
+    E[-1]=i0*(torch.dot(m,h)+.5*torch.dot(field,m))
+    return all_I,all_m,E
 
 
-def _multi_kernel(m, J, h, anneal, rnd, dt, threshold):
-    Nt, n_shots, n_pbits = rnd.shape
-    all_m = torch.empty(
-        (Nt, n_shots, n_pbits),
-        dtype=m.dtype, device=m.device
-    )
-
+def _multi_kernel(m,J,h,anneal,rnd,dt,threshold):
+    Nt,n_shots,n=rnd.shape
+    all_m=torch.empty((Nt,n_shots,n),dtype=m.dtype,device=m.device)
     for run in range(Nt):
-        I = anneal[run] * (m @ J + h)
-        s = torch.exp(-dt * torch.exp(-m * (I + threshold)))
-        m = m * torch.sign(s - rnd[run])
-        all_m[run] = m
-
+        I=anneal[run]*(m@J+h)
+        s=torch.exp(-dt*torch.exp(-m*(I+threshold)))
+        m=m*torch.sign(s-rnd[run])
+        all_m[run]=m
     return all_m
 
 
 class TorchCaSuDaSolver(Solver):
-
     def __init__(
-        self, Nt, dt, i0, expected_mean=0, seed=None,
-        device="cpu", dtype=torch.float32,
-        compile=False, cache_J=False,
+        self,Nt,dt,i0,expected_mean=0,seed=None,
+        device="cpu",dtype=torch.float32,compile=False,cache_J=False,
     ):
-        self.Nt = Nt
-        self.dt = dt
-        self.i0 = i0
-        self.expected_mean = expected_mean
-        self.seed = seed
-        self.device = device
-        self.dtype = dtype
-        self.compile = compile
-        self.cache_J = cache_J
-
-        if device == "cuda" and not torch.cuda.is_available():
+        if device=="spyre":
+            raise NotImplementedError("Spyre support is not enabled yet")
+        if cache_J:
+            raise NotImplementedError("cache_J is disabled because J may change in place")
+        if device not in ("cpu","cuda"):
+            raise ValueError("device must be 'cpu' or 'cuda'")
+        if device=="cuda" and not torch.cuda.is_available():
             raise RuntimeError("CUDA is not available")
 
-        if device == "spyre":
-            try:
-                import torch_spyre
-            except ImportError as e:
-                raise ImportError(
-                    "torch-spyre is required for device='spyre'"
-                ) from e
+        super().__init__(Nt,dt,i0,expected_mean,seed,device="cpu")
 
-        self.torch_device = torch.device(device)
-        self.rng_device = (
-            self.torch_device
-            if self.torch_device.type in ("cpu", "cuda")
-            else torch.device("cpu")
-        )
+        self.device=device
+        self.dtype=dtype
+        self.compile=compile
+        self.cache_J=False
+        self.torch_device=torch.device(device)
 
-        self.generator = torch.Generator(device=self.rng_device)
+        self.generator=torch.Generator(device=self.torch_device)
         if seed is not None:
             self.generator.manual_seed(seed)
 
-        self._J = None
-        self._J_key = None
-        self._anneal = None
-        self._anneal_key = None
+        self._anneal=None
+        self._anneal_key=None
 
         if compile:
-            self._single = torch.compile(
-                _single_kernel, mode="reduce-overhead"
-            )
-            self._multi = torch.compile(
-                _multi_kernel, mode="reduce-overhead"
-            )
+            self._single=torch.compile(_single_kernel,mode="reduce-overhead")
+            self._multi=torch.compile(_multi_kernel,mode="reduce-overhead")
         else:
-            self._single = _single_kernel
-            self._multi = _multi_kernel
+            self._single=_single_kernel
+            self._multi=_multi_kernel
+
+    def random(self,shape):
+        return self._random(shape)
 
     def clear_cache(self):
-        self._J = self._J_key = None
+        self._anneal=self._anneal_key=None
 
-    def _get_J(self, c):
-        if not self.cache_J:
-            return torch.as_tensor(
-                c.J, dtype=self.dtype, device=self.torch_device
-            )
+    def _get_J(self,c):
+        return torch.as_tensor(c.J,dtype=self.dtype,device=self.torch_device)
 
-        key = (id(c), id(c.J), c.J.shape)
-
-        if self._J is None or key != self._J_key:
-            self._J = torch.as_tensor(
-                c.J, dtype=self.dtype, device=self.torch_device
-            ).contiguous()
-            self._J_key = key
-
-        return self._J
-
-    def _annealing(self, annealing_func):
-        key = (id(annealing_func), self.Nt, float(self.i0))
-
-        if (
-            annealing_func is constant
-            and self._anneal is not None
-            and key == self._anneal_key
-        ):
+    def _annealing(self,func):
+        key=(id(func),self.Nt,float(self.i0))
+        if func is constant and self._anneal is not None and key==self._anneal_key:
             return self._anneal
 
-        values = [
-            float(annealing_func(self, run))
-            for run in range(self.Nt)
-        ]
-
-        anneal = torch.tensor(
-            values, dtype=self.dtype, device=self.torch_device
+        a=torch.tensor(
+            [float(func(self,run)) for run in range(self.Nt)],
+            dtype=self.dtype,device=self.torch_device
         )
+        if func is constant:
+            self._anneal=a; self._anneal_key=key
+        return a
 
-        if annealing_func is constant:
-            self._anneal = anneal
-            self._anneal_key = key
-
-        return anneal
-
-    def _random(self, shape):
-        x = torch.rand(
-            shape,
-            dtype=self.dtype,
-            device=self.rng_device,
-            generator=self.generator,
+    def _random(self,shape):
+        return torch.rand(
+            shape,dtype=self.dtype,device=self.torch_device,
+            generator=self.generator
         )
-
-        if self.rng_device != self.torch_device:
-            x = x.to(self.torch_device)
-
-        return x
 
     @torch.inference_mode()
-    def solve(
-        self, c: PCircuit, annealing_func=constant,
-        n_shots=1, initial_state=None,
-    ):
-        n_pbits = c.n_pbits
-        J = self._get_J(c)
-        h = torch.as_tensor(
+    def solve(self,c:PCircuit,annealing_func=constant,n_shots=1,initial_state=None):
+        n=c.n_pbits
+        J=self._get_J(c)
+        h=torch.as_tensor(
             np.asarray(c.h).reshape(-1),
-            dtype=self.dtype,
-            device=self.torch_device,
+            dtype=self.dtype,device=self.torch_device
         )
-
-        anneal = self._annealing(annealing_func)
-        threshold = float(np.arctanh(self.expected_mean))
-        shape = (n_pbits,) if n_shots == 1 else (n_shots, n_pbits)
+        anneal=self._annealing(annealing_func)
+        threshold=float(np.arctanh(self.expected_mean))
+        shape=(n,) if n_shots==1 else (n_shots,n)
 
         if initial_state is None:
-            m = torch.sign(0.5 - self._random(shape))
+            m=torch.sign(.5-self._random(shape))
         else:
-            state = np.asarray(initial_state)
+            if torch.is_tensor(initial_state):
+                state=initial_state.detach().to(self.torch_device,self.dtype)
+                if state.numel()!=n:
+                    raise ValueError(f"initial_state must contain {n} values")
+                state=state.reshape(n)
+                valid=bool(torch.all((state==-1)|(state==1)).item())
+            else:
+                state=np.asarray(initial_state)
+                if state.size!=n:
+                    raise ValueError(f"initial_state must contain {n} values")
+                state=state.reshape(n)
+                valid=np.all((state==-1)|(state==1))
+                state=torch.as_tensor(state,dtype=self.dtype,device=self.torch_device)
 
-            if state.size != n_pbits:
-                raise ValueError(
-                    f"initial_state must contain {n_pbits} values"
-                )
+            if not valid:
+                raise ValueError("initial_state must contain only -1 or +1")
 
-            state = state.reshape(n_pbits)
+            m=state.repeat(n_shots,1) if n_shots>1 else state
 
-            if not np.all((state == -1) | (state == 1)):
-                raise ValueError(
-                    "initial_state must contain only -1 or +1"
-                )
+        rnd=self._random((self.Nt,)+shape)
 
-            m = torch.as_tensor(
-                state, dtype=self.dtype, device=self.torch_device
+        if n_shots==1:
+            I,m,E=self._single(
+                m,J,h,anneal,rnd,self.dt,threshold,self.i0
             )
-
-            if n_shots > 1:
-                m = m.repeat(n_shots, 1)
-
-        rnd = self._random((self.Nt,) + shape)
-
-        if n_shots == 1:
-            all_I, all_m, E = self._single(
-                m, J, h, anneal, rnd,
-                self.dt, threshold, self.i0,
-            )
-
-            return (
-                all_I.cpu().numpy(),
-                all_m.cpu().numpy(),
-                E.cpu().numpy(),
-            )
+            return I.cpu().numpy(),m.cpu().numpy(),E.cpu().numpy()
 
         return self._multi(
-            m, J, h, anneal, rnd,
-            self.dt, threshold,
+            m,J,h,anneal,rnd,self.dt,threshold
         ).cpu().numpy()
 
     def copy(self):
         return TorchCaSuDaSolver(
-            self.Nt, self.dt, self.i0,
-            self.expected_mean, self.seed,
-            self.device, self.dtype,
-            self.compile, self.cache_J,
+            self.Nt,self.dt,self.i0,self.expected_mean,self.seed,
+            self.device,self.dtype,self.compile,False
         )

--- a/p_kit/solver/torch_csd_solver.py
+++ b/p_kit/solver/torch_csd_solver.py
@@ -1,0 +1,138 @@
+"""
+
+This is a version of CaSuDaSolver using PyTorch. 
+
+TorchCaSuDaSolver can allow an easy switch between CPU, GPU and for example
+IBM Spyre AI accelerator chip.
+
+From one hand it is good to have an alternative solver, but it also adds the
+heavy dependency of PyTorch. And it some respects the idea was not to use 
+PyTorch.
+
+
+"""
+
+import numpy as np
+import torch
+
+from p_kit.psl.p_circuit import PCircuit
+from p_kit.solver.annealing import constant
+from .base_solver import Solver
+
+
+class TorchCaSuDaSolver(Solver):
+    """PyTorch implementation of CaSuDaSolver."""
+
+    def __init__(
+        self, Nt, dt, i0, expected_mean=0, seed=None,
+        device="cpu", dtype=torch.float32, compile=False
+    ):
+        self.Nt = Nt
+        self.dt = dt
+        self.i0 = i0
+        self.expected_mean = expected_mean
+        self.seed = seed
+        self.device = device
+        self.dtype = dtype
+
+        if device == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+
+        if device == "spyre":
+            try:
+                import torch_spyre
+            except ImportError as e:
+                raise ImportError("torch-spyre is required for device='spyre'") from e
+
+        self.torch_device = torch.device(device)
+        self.generator = torch.Generator(device="cpu")
+        if seed is not None:
+            self.generator.manual_seed(seed)
+
+        self._step = torch.compile(self._torch_step) if compile else self._torch_step
+
+    @staticmethod
+    def _torch_step(m, J, h, anneal, dt, threshold, rnd):
+        I = anneal * (m @ J + h)
+        s = torch.exp(-dt * torch.exp(-m * (I + threshold)))
+        m = torch.where(rnd < s, m, -m)
+        return m, I
+
+    @torch.no_grad()
+    def solve(
+        self, c: PCircuit, annealing_func=constant,
+        n_shots=1, initial_state=None
+    ):
+        n_pbits = c.n_pbits
+        device = self.torch_device
+
+        J = torch.as_tensor(c.J, dtype=self.dtype, device=device)
+        h = torch.as_tensor(np.asarray(c.h).reshape(-1),
+                            dtype=self.dtype, device=device)
+        threshold = float(np.arctanh(self.expected_mean))
+
+        # Generate randomness on CPU once, then transfer once.
+        rnd = torch.rand(
+            (self.Nt + 1, n_shots, n_pbits),
+            generator=self.generator, dtype=self.dtype
+        ).to(device)
+
+        if initial_state is None:
+            m = torch.where(
+                rnd[0] < 0.5,
+                torch.ones((), dtype=self.dtype, device=device),
+                -torch.ones((), dtype=self.dtype, device=device),
+            )
+        else:
+            state = np.asarray(initial_state)
+            if state.size != n_pbits:
+                raise ValueError(
+                    f"initial_state must contain {n_pbits} values"
+                )
+            state = state.reshape(n_pbits)
+            if not np.all((state == -1) | (state == 1)):
+                raise ValueError(
+                    "initial_state must contain only -1 or +1"
+                )
+            state = torch.as_tensor(state, dtype=self.dtype, device=device)
+            m = state.unsqueeze(0).repeat(n_shots, 1)
+
+        all_m = torch.empty(
+            (self.Nt, n_shots, n_pbits),
+            dtype=self.dtype, device=device
+        )
+        all_I = torch.empty(
+            (self.Nt, n_pbits),
+            dtype=self.dtype, device=device
+        )
+        E = torch.empty(self.Nt, dtype=self.dtype, device=device)
+
+        for run in range(self.Nt):
+            anneal = float(annealing_func(self, run))
+
+            m, I = self._step(
+                m, J, h, anneal,
+                self.dt, threshold, rnd[run + 1]
+            )
+
+            all_m[run] = m
+            all_I[run] = I[0]
+            E[run] = self.i0 * (
+                torch.dot(m[0], h)
+                + 0.5 * torch.dot(m[0] @ J, m[0])
+            )
+
+        all_I = all_I.cpu().numpy()
+        all_m = all_m.cpu().numpy()
+        E = E.cpu().numpy()
+
+        if n_shots == 1:
+            return all_I, all_m[:, 0, :], E
+        return all_m
+
+    def copy(self):
+        return TorchCaSuDaSolver(
+            self.Nt, self.dt, self.i0,
+            self.expected_mean, self.seed,
+            self.device, self.dtype
+        )

--- a/p_kit/solver/torch_csd_solver.py
+++ b/p_kit/solver/torch_csd_solver.py
@@ -73,7 +73,8 @@ def _multi_kernel(m,J,h,anneal,rnd,dt,threshold):
 class TorchCaSuDaSolver(Solver):
     def __init__(
         self,Nt,dt,i0,expected_mean=0,seed=None,
-        device="cpu",dtype=torch.float32,compile=False,cache_J=False,
+        device="cpu",dtype=torch.float32,compile=False,
+        cache_J=False,tau=0.1,
     ):
         if device=="spyre":
             raise NotImplementedError("Spyre support is not enabled yet")
@@ -84,7 +85,7 @@ class TorchCaSuDaSolver(Solver):
         if device=="cuda" and not torch.cuda.is_available():
             raise RuntimeError("CUDA is not available")
 
-        super().__init__(Nt,dt,i0,expected_mean,seed,device="cpu")
+        super().__init__(Nt,dt,i0,expected_mean,seed,device="cpu",tau=tau)
 
         self.device=device
         self.dtype=dtype
@@ -221,6 +222,14 @@ class TorchCaSuDaSolver(Solver):
 
     def copy(self):
         return TorchCaSuDaSolver(
-            self.Nt,self.dt,self.i0,self.expected_mean,self.seed,
-            self.device,self.dtype,self.compile,False
+            Nt=self.Nt,
+            dt=self.dt,
+            i0=self.i0,
+            expected_mean=self.expected_mean,
+            seed=self.seed,
+            device=self.device,
+            dtype=self.dtype,
+            compile=self.compile,
+            cache_J=False,
+            tau=self.tau,
         )

--- a/p_kit/solver/torch_csd_solver.py
+++ b/p_kit/solver/torch_csd_solver.py
@@ -20,6 +20,15 @@ NOTES:
     annealing backend.
   - PyTorch and NumPy solvers use different random generators, so stochastic
     trajectories and final results are not expected to be identical.
+    
+  - TorchCaSuDaSolver is not fully optimized for CUDA yet.
+    Although the solver kernels run on the selected Torch device, solve()
+    returns NumPy arrays for compatibility with the existing p-kit API.
+    This requires copying results from GPU to CPU after every solve.
+    For recurrent workloads such as the language-model reservoir, repeated
+    CPU<->GPU transfers can significantly reduce the benefit of CUDA.
+    A future device-native solve_torch() path could keep J, h, state and
+    intermediate results as Torch tensors on the accelerator.
 """
 
 import numpy as np
@@ -126,7 +135,10 @@ class TorchCaSuDaSolver(Solver):
         )
 
     @torch.inference_mode()
-    def solve(self,c:PCircuit,annealing_func=constant,n_shots=1,initial_state=None):
+    def solve(
+        self,c:PCircuit,annealing_func=constant,n_shots=1,
+        bias_func=None,return_filtered=False,initial_state=None
+    ):
         n=c.n_pbits
         J=self._get_J(c)
         h=torch.as_tensor(
@@ -156,20 +168,56 @@ class TorchCaSuDaSolver(Solver):
 
             if not valid:
                 raise ValueError("initial_state must contain only -1 or +1")
-
             m=state.repeat(n_shots,1) if n_shots>1 else state
 
-        rnd=self._random((self.Nt,)+shape)
+        # Fast existing path
+        if bias_func is None and not return_filtered:
+            rnd=self._random((self.Nt,)+shape)
+            if n_shots==1:
+                I,m,E=self._single(m,J,h,anneal,rnd,self.dt,threshold,self.i0)
+                return I.cpu().numpy(),m.cpu().numpy(),E.cpu().numpy()
+            return self._multi(
+                m,J,h,anneal,rnd,self.dt,threshold
+            ).cpu().numpy()
+
+        # Full CaSuDaSolver-compatible path
+        if n_shots==1:
+            m=m.unsqueeze(0)
+
+        m_filt=torch.zeros_like(m)
+        all_m=torch.empty((self.Nt,n_shots,n),dtype=self.dtype,device=self.torch_device)
+        all_I=torch.empty((self.Nt,n),dtype=self.dtype,device=self.torch_device)
+        all_mfilt=torch.empty_like(all_m)
+        E=torch.empty(self.Nt,dtype=self.dtype,device=self.torch_device)
+
+        for run in range(self.Nt):
+            h_eff=h if bias_func is None else torch.as_tensor(
+                bias_func(run,m,m_filt),dtype=self.dtype,device=self.torch_device
+            )
+            I=anneal[run]*(m@J+h_eff)
+            s=torch.exp(-self.dt*torch.exp(-m*(I+threshold)))
+            m=m*torch.sign(s-self._random((n_shots,n)))
+            m_filt=(1-self.tau)*m_filt+self.tau*m
+
+            all_m[run]=m
+            all_I[run]=I[0]
+            all_mfilt[run]=m_filt
+
+            h0=h if bias_func is None else torch.broadcast_to(h_eff,(n_shots,n))[0]
+            E[run]=self.i0*(torch.dot(m[0],h0)+.5*torch.dot(m[0]@J,m[0]))
+
+        all_I=all_I.cpu().numpy()
+        all_m=all_m.cpu().numpy()
+        all_mfilt=all_mfilt.cpu().numpy()
+        E=E.cpu().numpy()
 
         if n_shots==1:
-            I,m,E=self._single(
-                m,J,h,anneal,rnd,self.dt,threshold,self.i0
-            )
-            return I.cpu().numpy(),m.cpu().numpy(),E.cpu().numpy()
-
-        return self._multi(
-            m,J,h,anneal,rnd,self.dt,threshold
-        ).cpu().numpy()
+            if return_filtered:
+                return all_I,all_m[:,0,:],E,all_mfilt[:,0,:]
+            return all_I,all_m[:,0,:],E
+        if return_filtered:
+            return all_m,all_mfilt
+        return all_m
 
     def copy(self):
         return TorchCaSuDaSolver(

--- a/p_kit/solver/torch_csd_solver.py
+++ b/p_kit/solver/torch_csd_solver.py
@@ -9,6 +9,17 @@ From one hand it is good to have an alternative solver, but it also adds the
 heavy dependency of PyTorch. And it some respects the idea was not to use 
 PyTorch.
 
+NOTES:
+  - The solver keeps the same PCircuit, J/h model and CaSuDa dynamics.
+  - It is intended mainly as an accelerator-oriented alternative backend.
+  - For small p-bit models, PyTorch CPU can be slower than the NumPy solver.
+  - GPU/accelerator benefits are expected mainly for larger workloads.
+  - cache_J=True improves performance when J remains fixed.
+  - If c.J is modified while cache_J=True, call solver.clear_cache().
+  - compile=True may improve accelerator performance but adds compilation overhead.
+  - device="spyre" requires torch-spyre and access to compatible Spyre hardware/runtime.
+  - PyTorch and NumPy solvers use different random generators, so stochastic
+    trajectories and final results are not expected to be identical.
 
 """
 
@@ -20,12 +31,57 @@ from p_kit.solver.annealing import constant
 from .base_solver import Solver
 
 
+def _single_kernel(m, J, h, anneal, rnd, dt, threshold, i0):
+    Nt, n_pbits = rnd.shape
+    all_m = torch.empty((Nt, n_pbits), dtype=m.dtype, device=m.device)
+    all_I = torch.empty_like(all_m)
+    E = torch.empty(Nt, dtype=m.dtype, device=m.device)
+
+    for run in range(Nt):
+        field = m @ J
+
+        if run:
+            E[run-1] = i0 * (
+                torch.dot(m, h) + 0.5 * torch.dot(field, m)
+            )
+
+        I = anneal[run] * (field + h)
+        s = torch.exp(-dt * torch.exp(-m * (I + threshold)))
+        m = m * torch.sign(s - rnd[run])
+
+        all_m[run] = m
+        all_I[run] = I
+
+    field = m @ J
+    E[-1] = i0 * (
+        torch.dot(m, h) + 0.5 * torch.dot(field, m)
+    )
+
+    return all_I, all_m, E
+
+
+def _multi_kernel(m, J, h, anneal, rnd, dt, threshold):
+    Nt, n_shots, n_pbits = rnd.shape
+    all_m = torch.empty(
+        (Nt, n_shots, n_pbits),
+        dtype=m.dtype, device=m.device
+    )
+
+    for run in range(Nt):
+        I = anneal[run] * (m @ J + h)
+        s = torch.exp(-dt * torch.exp(-m * (I + threshold)))
+        m = m * torch.sign(s - rnd[run])
+        all_m[run] = m
+
+    return all_m
+
+
 class TorchCaSuDaSolver(Solver):
-    """PyTorch implementation of CaSuDaSolver."""
 
     def __init__(
         self, Nt, dt, i0, expected_mean=0, seed=None,
-        device="cpu", dtype=torch.float32, compile=False
+        device="cpu", dtype=torch.float32,
+        compile=False, cache_J=False,
     ):
         self.Nt = Nt
         self.dt = dt
@@ -34,6 +90,8 @@ class TorchCaSuDaSolver(Solver):
         self.seed = seed
         self.device = device
         self.dtype = dtype
+        self.compile = compile
+        self.cache_J = cache_J
 
         if device == "cuda" and not torch.cuda.is_available():
             raise RuntimeError("CUDA is not available")
@@ -42,97 +100,158 @@ class TorchCaSuDaSolver(Solver):
             try:
                 import torch_spyre
             except ImportError as e:
-                raise ImportError("torch-spyre is required for device='spyre'") from e
+                raise ImportError(
+                    "torch-spyre is required for device='spyre'"
+                ) from e
 
         self.torch_device = torch.device(device)
-        self.generator = torch.Generator(device="cpu")
+        self.rng_device = (
+            self.torch_device
+            if self.torch_device.type in ("cpu", "cuda")
+            else torch.device("cpu")
+        )
+
+        self.generator = torch.Generator(device=self.rng_device)
         if seed is not None:
             self.generator.manual_seed(seed)
 
-        self._step = torch.compile(self._torch_step) if compile else self._torch_step
+        self._J = None
+        self._J_key = None
+        self._anneal = None
+        self._anneal_key = None
 
-    @staticmethod
-    def _torch_step(m, J, h, anneal, dt, threshold, rnd):
-        I = anneal * (m @ J + h)
-        s = torch.exp(-dt * torch.exp(-m * (I + threshold)))
-        m = torch.where(rnd < s, m, -m)
-        return m, I
-
-    @torch.no_grad()
-    def solve(
-        self, c: PCircuit, annealing_func=constant,
-        n_shots=1, initial_state=None
-    ):
-        n_pbits = c.n_pbits
-        device = self.torch_device
-
-        J = torch.as_tensor(c.J, dtype=self.dtype, device=device)
-        h = torch.as_tensor(np.asarray(c.h).reshape(-1),
-                            dtype=self.dtype, device=device)
-        threshold = float(np.arctanh(self.expected_mean))
-
-        # Generate randomness on CPU once, then transfer once.
-        rnd = torch.rand(
-            (self.Nt + 1, n_shots, n_pbits),
-            generator=self.generator, dtype=self.dtype
-        ).to(device)
-
-        if initial_state is None:
-            m = torch.where(
-                rnd[0] < 0.5,
-                torch.ones((), dtype=self.dtype, device=device),
-                -torch.ones((), dtype=self.dtype, device=device),
+        if compile:
+            self._single = torch.compile(
+                _single_kernel, mode="reduce-overhead"
+            )
+            self._multi = torch.compile(
+                _multi_kernel, mode="reduce-overhead"
             )
         else:
+            self._single = _single_kernel
+            self._multi = _multi_kernel
+
+    def clear_cache(self):
+        self._J = self._J_key = None
+
+    def _get_J(self, c):
+        if not self.cache_J:
+            return torch.as_tensor(
+                c.J, dtype=self.dtype, device=self.torch_device
+            )
+
+        key = (id(c), id(c.J), c.J.shape)
+
+        if self._J is None or key != self._J_key:
+            self._J = torch.as_tensor(
+                c.J, dtype=self.dtype, device=self.torch_device
+            ).contiguous()
+            self._J_key = key
+
+        return self._J
+
+    def _annealing(self, annealing_func):
+        key = (id(annealing_func), self.Nt, float(self.i0))
+
+        if (
+            annealing_func is constant
+            and self._anneal is not None
+            and key == self._anneal_key
+        ):
+            return self._anneal
+
+        values = [
+            float(annealing_func(self, run))
+            for run in range(self.Nt)
+        ]
+
+        anneal = torch.tensor(
+            values, dtype=self.dtype, device=self.torch_device
+        )
+
+        if annealing_func is constant:
+            self._anneal = anneal
+            self._anneal_key = key
+
+        return anneal
+
+    def _random(self, shape):
+        x = torch.rand(
+            shape,
+            dtype=self.dtype,
+            device=self.rng_device,
+            generator=self.generator,
+        )
+
+        if self.rng_device != self.torch_device:
+            x = x.to(self.torch_device)
+
+        return x
+
+    @torch.inference_mode()
+    def solve(
+        self, c: PCircuit, annealing_func=constant,
+        n_shots=1, initial_state=None,
+    ):
+        n_pbits = c.n_pbits
+        J = self._get_J(c)
+        h = torch.as_tensor(
+            np.asarray(c.h).reshape(-1),
+            dtype=self.dtype,
+            device=self.torch_device,
+        )
+
+        anneal = self._annealing(annealing_func)
+        threshold = float(np.arctanh(self.expected_mean))
+        shape = (n_pbits,) if n_shots == 1 else (n_shots, n_pbits)
+
+        if initial_state is None:
+            m = torch.sign(0.5 - self._random(shape))
+        else:
             state = np.asarray(initial_state)
+
             if state.size != n_pbits:
                 raise ValueError(
                     f"initial_state must contain {n_pbits} values"
                 )
+
             state = state.reshape(n_pbits)
+
             if not np.all((state == -1) | (state == 1)):
                 raise ValueError(
                     "initial_state must contain only -1 or +1"
                 )
-            state = torch.as_tensor(state, dtype=self.dtype, device=device)
-            m = state.unsqueeze(0).repeat(n_shots, 1)
 
-        all_m = torch.empty(
-            (self.Nt, n_shots, n_pbits),
-            dtype=self.dtype, device=device
-        )
-        all_I = torch.empty(
-            (self.Nt, n_pbits),
-            dtype=self.dtype, device=device
-        )
-        E = torch.empty(self.Nt, dtype=self.dtype, device=device)
-
-        for run in range(self.Nt):
-            anneal = float(annealing_func(self, run))
-
-            m, I = self._step(
-                m, J, h, anneal,
-                self.dt, threshold, rnd[run + 1]
+            m = torch.as_tensor(
+                state, dtype=self.dtype, device=self.torch_device
             )
 
-            all_m[run] = m
-            all_I[run] = I[0]
-            E[run] = self.i0 * (
-                torch.dot(m[0], h)
-                + 0.5 * torch.dot(m[0] @ J, m[0])
-            )
+            if n_shots > 1:
+                m = m.repeat(n_shots, 1)
 
-        all_I = all_I.cpu().numpy()
-        all_m = all_m.cpu().numpy()
-        E = E.cpu().numpy()
+        rnd = self._random((self.Nt,) + shape)
 
         if n_shots == 1:
-            return all_I, all_m[:, 0, :], E
-        return all_m
+            all_I, all_m, E = self._single(
+                m, J, h, anneal, rnd,
+                self.dt, threshold, self.i0,
+            )
+
+            return (
+                all_I.cpu().numpy(),
+                all_m.cpu().numpy(),
+                E.cpu().numpy(),
+            )
+
+        return self._multi(
+            m, J, h, anneal, rnd,
+            self.dt, threshold,
+        ).cpu().numpy()
 
     def copy(self):
         return TorchCaSuDaSolver(
             self.Nt, self.dt, self.i0,
             self.expected_mean, self.seed,
-            self.device, self.dtype
+            self.device, self.dtype,
+            self.compile, self.cache_J,
         )

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(name='p-kit',
       extras_require={
                       'tests': ['pytest', 'seaborn', 'flake8'],
                       'gpu': ['cupy-cuda13x'],
+                      'torch': ['torch'],
+                      'llm': ['torch', 'transformers'],
                       'docplex': ['docplex'],
                       },
       zip_safe=False,


### PR DESCRIPTION
Added a new Torch version of the CaSuDaSolver solver called TorchCaSuDaSolver.
An example that compares a LM over p-kit using several Solvers and a GPT as a baseline.
The demo shows that Solvers can be executed in both CPU and GPU mode.
TorchCaSuDaSolver is an optimized version, but its main benefit will come when a larger p-kit LM is used on CUDA.
TorchCaSuDaSolver can also run in the future on the IBM Spyre AI Accelerator or any other that is supported by PyTorch. 